### PR TITLE
Avoiding error when there are no good mics in a batch

### DIFF
--- a/cryoassess/protocols/protocol_micassess.py
+++ b/cryoassess/protocols/protocol_micassess.py
@@ -329,8 +329,10 @@ class CryoassessProtMics(ProtPreprocessMicrographs):
 
     def _getGoodMicFns(self, numPass):
         """ Parse output star file and get a list of good mics. """
-        table = Table(fileName=self.getOutputFilename(numPass), tableName='')
-        micNames = table.getColumnValues('rlnMicrographName')
+        micNames = []
+        if os.path.exists(self.getOutputFilename(numPass)):
+            table = Table(fileName=self.getOutputFilename(numPass), tableName='')
+            micNames = table.getColumnValues('rlnMicrographName')
         return micNames
 
     def _addGoodMic(self, item, row):


### PR DESCRIPTION
Running some tests I realized that if the threshold is too high and no good mics are found, a "file does not exist" error arises.
This check should fix it